### PR TITLE
fix: Apple Touch Icon being as browser icon

### DIFF
--- a/src/features/generateTagsFromPublicFiles.ts
+++ b/src/features/generateTagsFromPublicFiles.ts
@@ -28,10 +28,16 @@ export default async function generateTagsFromPublicFiles(nuxt: Nuxt = useNuxt()
         sizes: 'any',
       })
     }
+
+    const isIcon = (file: string) => file.includes('icon') && !file.endsWith('.ico');
+    const isAppleIcon = (file: string) => (
+      !isIcon(file) && (file.startsWith('apple-icon.') || file.startsWith('apple-touch-icon.'))
+    );
+
     headConfig.link.push(
       ...await Promise.all([
         ...rootPublicFiles
-          .filter(file => file.includes('icon') && !file.endsWith('.ico'))
+          .filter(file => isIcon(file))
           .sort()
           .map(async (iconFile) => {
             const iconFileExt = iconFile.split('.').pop()
@@ -43,7 +49,8 @@ export default async function generateTagsFromPublicFiles(nuxt: Nuxt = useNuxt()
               sizes,
             }
           }),
-        ...rootPublicFiles.filter(file => file.startsWith('apple-icon.') || file.startsWith('apple-touch-icon.'))
+        ...rootPublicFiles
+          .filter(file => isAppleIcon(file))
           .sort()
           .map(async (appleIconFile) => {
             const appleIconFileExt = appleIconFile.split('.').pop()


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes #11

Apple Icons were classifying as normal icons, since they have the text "icon" included in them.
I prevented apple icons from being a normal icon.

I can imagine to a very small number people who are using this plugin incorrectly that it could be a breaking change, however it's probably like 1 person.

### Linked Issues

#11

### Additional context

I couldn't run a dev server to see if this worked, here is what I've tried for that:
`pnpm run dev` *Notices the dev server doesn't start*
`pnpm run dev:prepare; pnpm run dev`
`git checkout main` *Ok, I guess I'll try to see if it didn't work before my changes*
`pnpm run dev` *Still doesn't seem to work*
`pnpm run dev:prepare; pnpm run dev` *hmm*

However, the code wasn't experimental, and I'm 90% sure it would work since I have a limited scope.

Tests passed, but I haven't edited tests to fail without this PR (partially because of the dev server thing).