### PR TITLE
docs: remove `nuxt.config` section in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,10 @@ Powerful SEO DX improvements that may or may not land in the Nuxt core.
 
 ## Installation
 
-1. Install `nuxt-seo-experiments` dependency to your project:
+Install `nuxt-seo-experiments` dependency to your project:
 
 ```bash
 npx nuxi@latest module add seo-experiments
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['nuxt-seo-experiments']
-})
 ```
 
 # Documentation


### PR DESCRIPTION

### Description

`nuxi module add` section has been added for simple-robots in #18  issue.

nuxt.config is automatically added by Nuxi, so I removed (2).

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
