### PR TITLE
fix: empty image url breaking page

### DIFF
--- a/src/runtime/nuxt/plugins/1.absoluteImageUrls.server.ts
+++ b/src/runtime/nuxt/plugins/1.absoluteImageUrls.server.ts
@@ -24,7 +24,7 @@ export default defineNuxtPlugin({
               continue
             if (tag.props.property !== 'og:image:url' && tag.props.property !== 'og:image' && tag.props.name !== 'twitter:image')
               continue
-            if (!tag.props.content || tag.props.content.startsWith('http') || tag.props.content.startsWith('//'))
+            if (typeof tag.props.content !== 'string' || !tag.props.content.trim() || tag.props.content.startsWith('http') || tag.props.content.startsWith('//'))
               continue
             tag.props.content = unref(resolver(tag.props.content))
           }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I opened this pull request to solve bug that occurs when image url is empty. More details in issue #20 

### Linked Issues
This should fix #20 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
